### PR TITLE
Fix typo (overivew -> overview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to PHP-Caches's Issue Tracker!
 [![Join the chat at https://gitter.im/php-cache/cache](https://badges.gitter.im/php-cache/cache.svg)](https://gitter.im/php-cache/cache?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 The issue tracker of this repository collects the issues of all the [PHP-Cache]
-components. Head over to [Issues] to display and create issues. You could also have a look on the overivew
+components. Head over to [Issues] to display and create issues. You could also have a look on the overview
 for the open [Pull requests]. 
 
 We use [Huboard](https://huboard.com/php-cache/issues) to get an overview over our issues and their status. 


### PR DESCRIPTION
This fixes a typo in README.